### PR TITLE
?src= のコード取得を render 中から useEffect に移動

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import Editor from "@monaco-editor/react";
 import { ButtonSelector, type Option } from "./components/ButtonSelector";
 import { Canvas } from "./components/Canvas";
@@ -49,11 +49,13 @@ const App = () => {
     );
   };
 
-  const [loading, setLoading] = useState<boolean>(true);
-  if (codeURL != undefined && loading) {
-    fetch(codeURL)
+  useEffect(() => {
+    if (codeURL == undefined) {
+      return;
+    }
+    const abort = new AbortController();
+    fetch(codeURL, { signal: abort.signal })
       .then(async (res) => {
-        setLoading(false);
         if (!res.ok) {
           setCode("// error: failed to load the code from URL");
           return;
@@ -63,11 +65,14 @@ const App = () => {
         AudioController.build(text);
       })
       .catch((e) => {
-        setLoading(false);
+        if (abort.signal.aborted) {
+          return;
+        }
         setCode("// error: failed to load the code from URL");
         console.error(e);
       });
-  }
+    return () => abort.abort();
+  }, [codeURL]);
 
   const getInputs = () => {
     AudioDevices.getDevices("audioinput")


### PR DESCRIPTION
## 概要

リポジトリレビュー(#17 の問題 3)の修正です。

`?src=` で指定された URL からのコード取得が render 本体で実行されていたため、以下の問題がありました。

- StrictMode では render が 2 回走るため fetch も 2 回発火する
- fetch が resolve するまでの間に再 render が起きるたびに fetch が追加発火する
- 読み込み中にエディタを編集すると、後から resolve した fetch が `setCode` で編集内容を上書きする

## 変更内容

- fetch を `useEffect` に移動し、`AbortController` でクリーンアップ時に中断するように変更
- 不要になった `loading` state を削除

## 確認

- `tsc -b` / `oxlint` / `prettier --check` すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
