### PR TITLE
setMIDI の removeEventListener が効いていない問題の修正

### DIFF
--- a/src/controller/AudioController.ts
+++ b/src/controller/AudioController.ts
@@ -63,19 +63,25 @@ const AudioController = class {
    * @param midi - MIDIInput (null=MIDI無効化)
    */
   public static async setMIDI(midi: MIDIInput | null) {
-    const onMIDIMessage = (event: MIDIMessageEvent) => {
-      if (event.data != null) {
-        AudioController.onMIDIMessage(event.data);
-      }
-    };
     const context = await AudioController.getContexts();
     if (context.midi != null) {
-      context.midi.removeEventListener("midimessage", onMIDIMessage);
+      context.midi.removeEventListener(
+        "midimessage",
+        AudioController.onMIDIEvent,
+      );
       await context.midi.close();
     }
     context.midi = midi;
-    context.midi?.addEventListener("midimessage", onMIDIMessage);
+    context.midi?.addEventListener("midimessage", AudioController.onMIDIEvent);
   }
+
+  // setMIDI のたびに新しいクロージャを作ると removeEventListener で解除できないため、
+  // リスナーは単一の参照を使い回す
+  private static onMIDIEvent = (event: MIDIMessageEvent) => {
+    if (event.data != null) {
+      AudioController.onMIDIMessage(event.data);
+    }
+  };
 
   /**
    * MIDI メッセージの送信


### PR DESCRIPTION
## 概要

リポジトリレビュー(#17 の問題 4)の修正です。

`setMIDI` 内で MIDI メッセージのリスナーを呼び出しごとに新しいクロージャとして作っていたため、`removeEventListener` に渡しても前回登録したリスナーとは別参照で、実際には解除できていませんでした。現状は直後の `midi.close()` に救われていますが、close が失敗した場合などにリスナーが多重登録され、1 打鍵で複数の NoteOn が届く恐れがあります。

## 変更内容

- リスナーを `private static onMIDIEvent` の単一参照に変更し、add/remove で同じ参照を使うように修正

## 確認

- `tsc -b` / `oxlint` / `prettier --check` すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
