### PR TITLE
onDraw を useCallback で固定し Canvas の描画ループ再起動を防ぐ

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import Editor from "@monaco-editor/react";
 import { ButtonSelector, type Option } from "./components/ButtonSelector";
 import { Canvas } from "./components/Canvas";
@@ -139,14 +139,19 @@ const App = () => {
     AudioController.build(code);
   };
 
-  const onDraw = (
-    w: number,
-    h: number,
-    mouse: { x: number; y: number; pressedL: boolean; pressedR: boolean },
-  ) => {
-    AudioController.draw(w, h, mouse);
-    return AudioController.getShapes();
-  };
+  // 参照が毎 render 変わると Canvas 側の useEffect が再実行され、
+  // 描画ループの再生成やマウス状態のリセットが起きるため useCallback で固定する
+  const onDraw = useCallback(
+    (
+      w: number,
+      h: number,
+      mouse: { x: number; y: number; pressedL: boolean; pressedR: boolean },
+    ) => {
+      AudioController.draw(w, h, mouse);
+      return AudioController.getShapes();
+    },
+    [],
+  );
 
   const appRef = useRef<HTMLDivElement>(null);
   useEffect(() => {


### PR DESCRIPTION
## 概要

リポジトリレビュー(#17 の問題 6)の修正です。

`App` の `onDraw` は render ごとに新しい関数として作られるため、`Canvas` 側の `useEffect`(依存配列に `onDraw` を含む)が再実行されていました。エディタの 1 キーストロークごとに以下が起きます。

- requestAnimationFrame ループの破棄・再生成
- ポインタイベントリスナーの付け替え
- マウス状態のリセット(ドラッグ中に再 render が起きると座標が (0,0) に飛ぶ)

## 変更内容

- `onDraw` を `useCallback(..., [])` で包み参照を固定(参照先は static メソッドのみなので依存なしで安全)

## 確認

- `tsc -b` / `oxlint` / `prettier --check` すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
