### PR TITLE
touchmove リスナーの登録を useEffect に移動

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import Editor from "@monaco-editor/react";
 import { ButtonSelector, type Option } from "./components/ButtonSelector";
 import { Canvas } from "./components/Canvas";
@@ -148,13 +148,17 @@ const App = () => {
   };
 
   const appRef = useRef<HTMLDivElement>(null);
-  appRef.current?.addEventListener(
-    "touchmove",
-    (e) => {
+  useEffect(() => {
+    const app = appRef.current;
+    if (app == null) {
+      return;
+    }
+    const onTouchMove = (e: TouchEvent) => {
       e.preventDefault();
-    },
-    { passive: false },
-  );
+    };
+    app.addEventListener("touchmove", onTouchMove, { passive: false });
+    return () => app.removeEventListener("touchmove", onTouchMove);
+  }, []);
 
   return (
     <div ref={appRef} className="flex flex-col h-dvh select-none">


### PR DESCRIPTION
## 概要

リポジトリレビュー(#17 の問題 7)の修正です。

`appRef.current?.addEventListener("touchmove", ...)` が render 本体にあるため、再 render のたびに新しいリスナーが追加され続けていました。また初回 render 時は `appRef.current` が null のため登録されず、2 回目以降の render で初めて有効になるという問題もありました。

## 変更内容

- リスナー登録を `useEffect` に移動し、クリーンアップで解除するように変更

## 確認

- `tsc -b` / `oxlint` / `prettier --check` すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
