### PR TITLE
入力コピーのループ変数の取り違えを修正

### DIFF
--- a/src/controller/AudioControllerWorker.ts
+++ b/src/controller/AudioControllerWorker.ts
@@ -134,7 +134,7 @@ class WaveformProcessor extends AudioWorkletProcessor {
             Math.min(inputs[input][ch].length, outputs[input][ch].length);
             sample++
           ) {
-            outputs[input][ch][sample] = inputs[0][ch][sample];
+            outputs[input][ch][sample] = inputs[input][ch][sample];
           }
         }
       }


### PR DESCRIPTION
## 概要

リポジトリレビュー(#17 の問題 9)の修正です。

`AudioControllerWorker.ts` の入力→出力コピーで、`input` でループしているのに読み出し元が `inputs[0][ch][sample]` に固定されていました。現在は `numberOfInputs: 1` のため実害はありませんが、入力数を増やした瞬間に全入力へ 1 番目の入力がコピーされるバグになります。

## 変更内容

- `inputs[0][ch][sample]` → `inputs[input][ch][sample]`

## 確認

- `tsc -b` / `oxlint` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
