### PR TITLE
ホットリロードのタイマー ID を useState から useRef に変更

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,25 +28,21 @@ const App = () => {
       ? (localStorage.getItem("code") ?? defaultProcessorCode)
       : "// loading...",
   );
-  const [hotReloadTimeout, sethotReloadTimeout] = useState<
-    number | undefined
-  >();
+  const hotReloadTimeout = useRef<number | undefined>(undefined);
   const onCodeChange = (code?: string) => {
-    if (hotReloadTimeout != undefined) {
-      clearTimeout(hotReloadTimeout);
+    if (hotReloadTimeout.current != undefined) {
+      clearTimeout(hotReloadTimeout.current);
     }
     if (code == undefined) {
       return;
     }
     setCode(code);
-    sethotReloadTimeout(
-      setTimeout(() => {
-        AudioController.build(code);
-        if (codeURL == undefined) {
-          localStorage.setItem("code", code);
-        }
-      }, 1000),
-    );
+    hotReloadTimeout.current = setTimeout(() => {
+      AudioController.build(code);
+      if (codeURL == undefined) {
+        localStorage.setItem("code", code);
+      }
+    }, 1000);
   };
 
   const [loading, setLoading] = useState<boolean>(true);


### PR DESCRIPTION
## 概要

リポジトリレビュー(#17 の問題 10)の修正です。

ホットリロード用の `setTimeout` の ID を `useState` で保持していましたが、タイマー ID は描画に関係ない値のため `useRef` が適切です。`useState` の場合は以下の問題があります。

- キーストロークごとに不要な再 render が 1 回増える
- state 更新が反映される前に `onChange` が再度呼ばれると、古い ID を参照して `clearTimeout` が漏れる余地がある

## 変更内容

- `hotReloadTimeout` を `useRef<number | undefined>` に変更

## 確認

- `tsc -b` / `oxlint` / `prettier --check` すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
