### PR TITLE
出力デバイスの ButtonSelector にも disabled を指定

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -210,6 +210,7 @@ const App = () => {
           icon="volume_up"
           enable={outputToggle}
           options={outputs ?? []}
+          disabled={outputs === null}
           onOpen={getOutputs}
           onChange={setOutput}
         />


### PR DESCRIPTION
## 概要

リポジトリレビュー(#17 の問題 11)の修正です。

マイク (`inputs`)・MIDI (`midis`) のセレクタは権限拒否時 (`null`) に `disabled` でグレー表示になりますが、出力デバイス (`outputs`) のセレクタだけ `disabled` の指定が漏れており、権限拒否時に空のリストが開くだけになっていました。

## 変更内容

- `disabled={outputs === null}` を追加し、他のセレクタと表示を統一

## 確認

- `tsc -b` / `oxlint` / `prettier --check` すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
