### PR TITLE
CI の再現性を向上

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -33,10 +33,16 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 'latest'
+          # LTS に固定して Node の破壊的変更でビルドが突然壊れるのを防ぐ
+          node-version: '24'
           cache: 'npm'
       - name: Install dependencies
-        run: npm install
+        # lockfile 通りの再現ビルドにする
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Check formatting
+        run: npx prettier --check ./lib ./src ./public
       - name: Build
         run: npm run build
       - name: Setup Pages


### PR DESCRIPTION
## 概要

リポジトリレビュー(#17 の問題 15)の対応です。

## 変更内容

- `node-version: 'latest'` → `'24'`(LTS)に固定し、Node の破壊的変更でビルドが突然壊れるのを防止
- `npm install` → `npm ci` に変更し、lockfile 通りの再現ビルドに
- デプロイ前に `npm run lint` と `prettier --check` を実行するステップを追加(現状どちらもクリーンであることをローカルで確認済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
