### PR TITLE
sampler.js の vec2 ユーティリティの参照ミスを修正

### DIFF
--- a/public/examples/examples/sampler.js
+++ b/public/examples/examples/sampler.js
@@ -62,8 +62,8 @@ const vec2 = {
    * @description ベクトル長が 1 になるよう正規化
    */
   unit: (a) => {
-    const len = len(a);
-    return len > 1e-6 ? div(a, len) : [1, 0];
+    const len = vec2.len(a);
+    return len > 1e-6 ? vec2.div(a, len) : [1, 0];
   },
 
   /**
@@ -86,7 +86,7 @@ const vec2 = {
     ][Math.floor(r) - Math.floor(r / 4) * 4];
   },
 
-  get_rot: (a) => Math.atan2(a.y, a.x),
+  get_rot: (a) => Math.atan2(a[1], a[0]),
 
   /**
    * @description 直線と直線の交点を取得
@@ -96,7 +96,7 @@ const vec2 = {
     // <=>      s*av - t*bv = bp - ap
     // <=> [av bv] [s -t]^T = bp - ap
     // <=>         [s -t]^T = [av bv]^-1 (bp - ap)
-    const bpap = sub(bp, ap);
+    const bpap = vec2.sub(bp, ap);
     const det = av[0] * bv[1] - av[1] * bv[0];
     const s = (bv[1] * bpap[0] - bv[0] * bpap[1]) / det;
     return s;


### PR DESCRIPTION
## 概要

リポジトリレビュー(#17 の問題 16)の修正です。

`public/examples/examples/sampler.js` の `vec2` ユーティリティに、呼び出すと実行時エラーになる参照ミスがありました。いずれも現在は未使用のため実害はありませんが、example はユーザーがコピーして使う想定のため修正します。

## 変更内容

- `vec2.unit`: 裸の `len(a)` / `div(a, len)` → `vec2.len(a)` / `vec2.div(a, len)`(呼ぶと ReferenceError)
- `vec2.intersection`: 裸の `sub(bp, ap)` → `vec2.sub(bp, ap)`(同上)
- `vec2.get_rot`: 配列要素なのに `a.y` / `a.x` を参照 → `a[1]` / `a[0]`(常に NaN を返していた)

## 確認

- `node --check` / `oxlint` / `prettier --check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
