### PR TITLE
ドロップダウンがタッチデバイスで閉じない問題の修正

### DIFF
--- a/src/components/ButtonSelector.tsx
+++ b/src/components/ButtonSelector.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 
 export type Option = { id: string; name: string };
 
@@ -32,8 +32,30 @@ export const ButtonSelector = (args: ButtonSelectorArgs) => {
     setSelectedId(id);
   };
 
+  // タッチデバイスでは mouseleave が発火しないため、外側のタップでも閉じる
+  const rootRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const onPointerDown = (e: PointerEvent) => {
+      if (!(e.target instanceof Node)) {
+        return;
+      }
+      if (rootRef.current != null && !rootRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
   return (
-    <div onMouseLeave={() => setOpen(false)} className="flex flex-col h-full">
+    <div
+      ref={rootRef}
+      onMouseLeave={() => setOpen(false)}
+      className="flex flex-col h-full"
+    >
       <div
         className="
           flex flex-row h-full rounded-full bg-zinc-700/50


### PR DESCRIPTION
## 概要

リポジトリレビュー(#17 の問題 17)の修正です。

`ButtonSelector` のドロップダウンは `onMouseLeave` でのみ閉じる設計のため、mouseleave イベントが発火しないタッチデバイスでは一度開くと閉じられませんでした。

## 変更内容

- ドロップダウンが開いている間だけ `document` の `pointerdown` を監視し、コンポーネント外側のタップ・クリックで閉じるように変更
- 既存の `onMouseLeave` による挙動(マウス操作)はそのまま維持

## 備考

#17 の問題 17 のその他の項目は以下の理由で見送りました。

- `./license.md` の dev 404: 本番ビルドでは Vite が生成するため実害が dev に限られる
- Google Fonts のセルフホスト化: 依存追加を伴うため方針確認が必要
- Keyboard の `pressed` state 共有: グリッサンド時の見た目調整として意図的の可能性があるため

## 確認

- `tsc -b` / `oxlint` / `prettier --check` すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
